### PR TITLE
Docs and test cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "folktime"
-version = "0.3.0"
+version = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "folktime"
 description = "Tiny no_std, zero-allocation library for approximate human-friendly duration formatting."
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/lkurcak/folktime"
 keywords = ["duration", "formatting", "human-readable", "no-std", "no-alloc"]
-categories = ["date-and-time", "value-formatting", "no-std::no-alloc"]
+categories = ["date-and-time", "value-formatting", "no-std", "no-std::no-alloc"]
 
 [lib]
 path = "src/lib.rs"

--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@
 [![CI](https://github.com/lkurcak/folktime/workflows/CI/badge.svg)](https://github.com/lkurcak/folktime/actions)
 [![Crates.io](https://img.shields.io/crates/v/folktime.svg)](https://crates.io/crates/folktime)
 
-Tiny `no_std`, zero-allocation library for approximate formatting of [std::time::Duration](https://doc.rust-lang.org/stable/core/time/struct.Duration.html) in a human-friendly way.
+Tiny `no_std`, zero-allocation library for approximate formatting of [Duration](https://doc.rust-lang.org/stable/core/time/struct.Duration.html) in a human-friendly way.
 
 If you are looking for a full precision human readable format, take a look at [humantime](https://crates.io/crates/humantime).
 
 ### Usage
 
 ```rust
-use std::time::Duration;
+use core::time::Duration;
 use folktime::Folktime;
 
 let a = Folktime::duration(Duration::from_secs(5));
-assert_eq!(format!("{}", a), "5.00s");
+assert_eq!(format!("{a}"), "5.00s");
 ```
 
 ### Precision
@@ -22,7 +22,7 @@ assert_eq!(format!("{}", a), "5.00s");
 Formatting only shows the most significant digits:
 
 ```rust
-use std::time::Duration;
+use core::time::Duration;
 use folktime::Folktime;
 
 let a = Folktime::duration(Duration::new(0, 123_456_789));
@@ -30,10 +30,10 @@ let b = Folktime::duration(Duration::new(1, 123_456_789));
 let c = Folktime::duration(Duration::new(12, 123_456_789));
 let d = Folktime::duration(Duration::new(123, 123_456_789));
 
-assert_eq!(format!("{}", a), "123ms");
-assert_eq!(format!("{}", b), "1.12s");
-assert_eq!(format!("{}", c), "12.1s");
-assert_eq!(format!("{}", d), "2.05m");
+assert_eq!(format!("{a}"), "123ms");
+assert_eq!(format!("{b}"), "1.12s");
+assert_eq!(format!("{c}"), "12.1s");
+assert_eq!(format!("{d}"), "2.05m");
 ```
 
 ### Formatting styles
@@ -41,7 +41,7 @@ assert_eq!(format!("{}", d), "2.05m");
 There are several styles for formatting:
 
 ```rust
-use std::time::Duration;
+use core::time::Duration;
 use folktime::Folktime;
 use folktime::duration::Style;
 
@@ -49,9 +49,9 @@ let a = Folktime::duration(Duration::new(0, 12_056_999));
 let b = Folktime::duration(Duration::new(0, 12_056_999)).with_style(Style::OneUnitWhole);
 let c = Folktime::duration(Duration::new(0, 12_056_999)).with_style(Style::TwoUnitsWhole);
 
-assert_eq!(format!("{}", a), "12.0ms");
-assert_eq!(format!("{}", b), "12ms");
-assert_eq!(format!("{}", c), "12ms 56us");
+assert_eq!(format!("{a}"), "12.0ms");
+assert_eq!(format!("{b}"), "12ms");
+assert_eq!(format!("{c}"), "12ms 56us");
 ```
 
 ### Minimum unit
@@ -59,12 +59,14 @@ assert_eq!(format!("{}", c), "12ms 56us");
 Use `with_min_unit` to set a floor on the displayed unit:
 
 ```rust
-use std::time::Duration;
+use core::time::Duration;
 use folktime::Folktime;
 use folktime::duration::Unit;
 
-let d = Folktime::duration(Duration::from_millis(500)).with_min_unit(Unit::Second);
-assert_eq!(format!("{}", d), "0.50s");
+let a = Folktime::duration(Duration::from_millis(500));
+let b = Folktime::duration(Duration::from_millis(500)).with_min_unit(Unit::Second);
+assert_eq!(format!("{a}"), "500ms");
+assert_eq!(format!("{b}"), "0.50s");
 ```
 
 Here's a comparison of styles:
@@ -80,4 +82,3 @@ Here's a comparison of styles:
 | 12345678s  | `2.04w`              | `2w`                  | `2w 0d`                |
 | 123456789s | `4.69mo`             | `4mo`                 | `4mo 21d`              |
 | max        | `584Gy`              | `584Gy`               | `584Gy 4mo`            |
-

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -22,13 +22,13 @@ const MS: u32 = 1_000 * US;
 ///
 /// # Example
 /// ```
-/// use std::time::Duration;
+/// use core::time::Duration;
 /// use folktime::Folktime;
 /// use folktime::duration::Unit;
 ///
 /// let d = Folktime::duration(Duration::from_millis(500))
 ///     .with_min_unit(Unit::Second);
-/// assert_eq!(format!("{}", d), "0.50s");
+/// assert_eq!(format!("{d}"), "0.50s");
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Unit {
@@ -67,36 +67,36 @@ pub enum Style {
     ///
     /// # Example
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// use folktime::Folktime;
     /// use folktime::duration::Style;
     ///
     /// let d = Folktime::duration(Duration::from_secs(123)).with_style(Style::OneUnitFrac);
-    /// assert_eq!(format!("{}", d), "2.05m");
+    /// assert_eq!(format!("{d}"), "2.05m");
     /// ```
     OneUnitFrac,
     /// Format the duration in the largest possible unit with a whole number.
     ///
     /// # Example
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// use folktime::Folktime;
     /// use folktime::duration::Style;
     ///
     /// let d = Folktime::duration(Duration::from_secs(123)).with_style(Style::OneUnitWhole);
-    /// assert_eq!(format!("{}", d), "2m");
+    /// assert_eq!(format!("{d}"), "2m");
     /// ```
     OneUnitWhole,
     /// Format the duration in the two largest possible units with whole numbers.
     ///
     /// # Example
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// use folktime::Folktime;
     /// use folktime::duration::Style;
     ///
     /// let d = Folktime::duration(Duration::from_secs(123)).with_style(Style::TwoUnitsWhole);
-    /// assert_eq!(format!("{}", d), "2m 3s");
+    /// assert_eq!(format!("{d}"), "2m 3s");
     /// ```
     TwoUnitsWhole,
 }
@@ -123,12 +123,12 @@ impl Duration {
     ///
     /// # Example
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// use folktime::Folktime;
     /// use folktime::duration::Style;
     ///
     /// let d = Folktime::duration(Duration::from_secs(123)).with_style(Style::TwoUnitsWhole);
-    /// assert_eq!(format!("{}", d), "2m 3s");
+    /// assert_eq!(format!("{d}"), "2m 3s");
     /// ```
     #[must_use]
     pub const fn with_style(self, style: Style) -> Self {
@@ -147,18 +147,18 @@ impl Duration {
     ///
     /// # Example
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// use folktime::Folktime;
     /// use folktime::duration::{Style, Unit};
     ///
     /// let d = Folktime::duration(Duration::from_millis(500))
     ///     .with_min_unit(Unit::Second);
-    /// assert_eq!(format!("{}", d), "0.50s");
+    /// assert_eq!(format!("{d}"), "0.50s");
     ///
     /// let d = Folktime::duration(Duration::from_millis(500))
     ///     .with_style(Style::OneUnitWhole)
     ///     .with_min_unit(Unit::Second);
-    /// assert_eq!(format!("{}", d), "0s");
+    /// assert_eq!(format!("{d}"), "0s");
     /// ```
     #[must_use]
     pub const fn with_min_unit(self, unit: Unit) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,15 @@ pub mod duration;
 
 use duration::Duration;
 
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+mod readme_doctests {}
+
 /// Entry point for formatting values.
 ///
 /// # Example
 /// ```
-/// use std::time::Duration;
+/// use core::time::Duration;
 /// use folktime::Folktime;
 ///
 /// let d = Folktime::duration(Duration::from_secs(5));
@@ -24,7 +28,7 @@ impl Folktime {
     ///
     /// # Example
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// use folktime::Folktime;
     ///
     /// let d = Folktime::duration(Duration::from_secs(5));
@@ -35,7 +39,7 @@ impl Folktime {
     ///
     /// Formatting only shows the most significant digits:
     /// ```
-    /// # use std::time::Duration;
+    /// # use core::time::Duration;
     /// # use folktime::Folktime;
     /// #
     /// let a = Folktime::duration(Duration::new(0, 123_456_789));
@@ -52,7 +56,7 @@ impl Folktime {
     /// # Formatting styles
     /// There are several styles for formatting:
     /// ```
-    /// # use std::time::Duration;
+    /// # use core::time::Duration;
     /// # use folktime::Folktime;
     /// use folktime::duration::Style;
     ///
@@ -68,7 +72,7 @@ impl Folktime {
     /// # Minimum unit
     /// Use [`Duration::with_min_unit`] to set a floor on the displayed unit:
     /// ```
-    /// # use std::time::Duration;
+    /// # use core::time::Duration;
     /// # use folktime::Folktime;
     /// use folktime::duration::Unit;
     ///

--- a/tests/min_unit.rs
+++ b/tests/min_unit.rs
@@ -1,6 +1,6 @@
+use core::time::Duration;
 use folktime::Folktime;
 use folktime::duration::{Style, Unit};
-use std::time::Duration;
 
 // --- OneUnitWhole with min_unit = Second ---
 

--- a/tests/no_alloc.rs
+++ b/tests/no_alloc.rs
@@ -1,7 +1,7 @@
 use core::fmt::Write;
+use core::time::Duration;
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::Cell;
-use std::time::Duration;
 
 use folktime::Folktime;
 use folktime::duration::{Style, Unit};
@@ -203,6 +203,6 @@ fn two_units_whole_does_not_allocate() {
 fn with_min_unit_does_not_allocate() {
     assert_no_alloc(|buf| {
         let d = Folktime::duration(Duration::from_millis(500)).with_min_unit(Unit::Second);
-        write!(buf, "{}", d).unwrap();
+        write!(buf, "{d}").unwrap();
     });
 }

--- a/tests/one_unit_frac.rs
+++ b/tests/one_unit_frac.rs
@@ -1,417 +1,417 @@
 mod common;
 
 use common::*;
+use core::time::Duration;
 use folktime::Folktime;
 use folktime::duration::Style;
-use std::time::Duration;
 
 const STYLE: Style = Style::OneUnitFrac;
 
 #[test]
 fn zero() {
     let d = Folktime::duration(Duration::new(0, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "0.00s");
+    assert_eq!(format!("{d}"), "0.00s");
 }
 #[test]
 fn max() {
     let d = Folktime::duration(Duration::new(u64::MAX, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "584Gy");
+    assert_eq!(format!("{d}"), "584Gy");
 }
 #[test]
 fn test() {
     let d = Folktime::duration(Duration::from_secs(12345689)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "4.69mo");
+    assert_eq!(format!("{d}"), "4.69mo");
 }
 #[test]
 fn test2() {
     let d = Folktime::duration(Duration::from_secs(1234568)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2.04w");
+    assert_eq!(format!("{d}"), "2.04w");
 }
 
 #[test]
 fn ns_0() {
     let d = Folktime::duration(Duration::new(0, 1)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ns");
+    assert_eq!(format!("{d}"), "1ns");
 }
 #[test]
 fn ns_1() {
     let d = Folktime::duration(Duration::new(0, 999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999ns");
+    assert_eq!(format!("{d}"), "999ns");
 }
 
 #[test]
 fn us_0() {
     let d = Folktime::duration(Duration::new(0, 1_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00us");
+    assert_eq!(format!("{d}"), "1.00us");
 }
 #[test]
 fn us_1() {
     let d = Folktime::duration(Duration::new(0, 1_001)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00us");
+    assert_eq!(format!("{d}"), "1.00us");
 }
 #[test]
 fn us_2() {
     let d = Folktime::duration(Duration::new(0, 1_009)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00us");
+    assert_eq!(format!("{d}"), "1.00us");
 }
 #[test]
 fn us_3() {
     let d = Folktime::duration(Duration::new(0, 1_010)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.01us");
+    assert_eq!(format!("{d}"), "1.01us");
 }
 #[test]
 fn us_4() {
     let d = Folktime::duration(Duration::new(0, 1_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.99us");
+    assert_eq!(format!("{d}"), "1.99us");
 }
 #[test]
 fn us_5() {
     let d = Folktime::duration(Duration::new(0, 9_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "9.99us");
+    assert_eq!(format!("{d}"), "9.99us");
 }
 #[test]
 fn us_6() {
     let d = Folktime::duration(Duration::new(0, 10_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0us");
+    assert_eq!(format!("{d}"), "10.0us");
 }
 #[test]
 fn us_7() {
     let d = Folktime::duration(Duration::new(0, 10_099)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0us");
+    assert_eq!(format!("{d}"), "10.0us");
 }
 #[test]
 fn us_8() {
     let d = Folktime::duration(Duration::new(0, 10_100)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.1us");
+    assert_eq!(format!("{d}"), "10.1us");
 }
 #[test]
 fn us_9() {
     let d = Folktime::duration(Duration::new(0, 99_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "99.9us");
+    assert_eq!(format!("{d}"), "99.9us");
 }
 #[test]
 fn us_10() {
     let d = Folktime::duration(Duration::new(0, 100_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "100us");
+    assert_eq!(format!("{d}"), "100us");
 }
 #[test]
 fn us_11() {
     let d = Folktime::duration(Duration::new(0, 100_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "100us");
+    assert_eq!(format!("{d}"), "100us");
 }
 #[test]
 fn us_12() {
     let d = Folktime::duration(Duration::new(0, 101_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "101us");
+    assert_eq!(format!("{d}"), "101us");
 }
 #[test]
 fn us_13() {
     let d = Folktime::duration(Duration::new(0, 999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999us");
+    assert_eq!(format!("{d}"), "999us");
 }
 
 #[test]
 fn ms_0() {
     let d = Folktime::duration(Duration::new(0, 1_000_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00ms");
+    assert_eq!(format!("{d}"), "1.00ms");
 }
 #[test]
 fn ms_1() {
     let d = Folktime::duration(Duration::new(0, 1_009_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00ms");
+    assert_eq!(format!("{d}"), "1.00ms");
 }
 #[test]
 fn ms_2() {
     let d = Folktime::duration(Duration::new(0, 1_010_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.01ms");
+    assert_eq!(format!("{d}"), "1.01ms");
 }
 #[test]
 fn ms_3() {
     let d = Folktime::duration(Duration::new(0, 9_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "9.99ms");
+    assert_eq!(format!("{d}"), "9.99ms");
 }
 #[test]
 fn ms_4() {
     let d = Folktime::duration(Duration::new(0, 10_000_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0ms");
+    assert_eq!(format!("{d}"), "10.0ms");
 }
 #[test]
 fn ms_5() {
     let d = Folktime::duration(Duration::new(0, 10_099_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0ms");
+    assert_eq!(format!("{d}"), "10.0ms");
 }
 #[test]
 fn ms_6() {
     let d = Folktime::duration(Duration::new(0, 10_100_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.1ms");
+    assert_eq!(format!("{d}"), "10.1ms");
 }
 #[test]
 fn ms_7() {
     let d = Folktime::duration(Duration::new(0, 99_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "99.9ms");
+    assert_eq!(format!("{d}"), "99.9ms");
 }
 #[test]
 fn ms_8() {
     let d = Folktime::duration(Duration::new(0, 100_000_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "100ms");
+    assert_eq!(format!("{d}"), "100ms");
 }
 #[test]
 fn ms_9() {
     let d = Folktime::duration(Duration::new(0, 100_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "100ms");
+    assert_eq!(format!("{d}"), "100ms");
 }
 #[test]
 fn ms_10() {
     let d = Folktime::duration(Duration::new(0, 101_000_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "101ms");
+    assert_eq!(format!("{d}"), "101ms");
 }
 #[test]
 fn ms_11() {
     let d = Folktime::duration(Duration::new(0, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999ms");
+    assert_eq!(format!("{d}"), "999ms");
 }
 
 #[test]
 fn s_0() {
     let d = Folktime::duration(Duration::new(1, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00s");
+    assert_eq!(format!("{d}"), "1.00s");
 }
 #[test]
 fn s_1() {
     let d = Folktime::duration(Duration::new(1, 9_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00s");
+    assert_eq!(format!("{d}"), "1.00s");
 }
 #[test]
 fn s_2() {
     let d = Folktime::duration(Duration::new(1, 10_000_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.01s");
+    assert_eq!(format!("{d}"), "1.01s");
 }
 #[test]
 fn s_3() {
     let d = Folktime::duration(Duration::new(9, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "9.99s");
+    assert_eq!(format!("{d}"), "9.99s");
 }
 #[test]
 fn s_4() {
     let d = Folktime::duration(Duration::new(10, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0s");
+    assert_eq!(format!("{d}"), "10.0s");
 }
 #[test]
 fn s_5() {
     let d = Folktime::duration(Duration::new(10, 99_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0s");
+    assert_eq!(format!("{d}"), "10.0s");
 }
 #[test]
 fn s_6() {
     let d = Folktime::duration(Duration::new(10, 100_000_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.1s");
+    assert_eq!(format!("{d}"), "10.1s");
 }
 #[test]
 fn s_7() {
     let d = Folktime::duration(Duration::new(59, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "59.9s");
+    assert_eq!(format!("{d}"), "59.9s");
 }
 
 #[test]
 fn m_0() {
     let d = Folktime::duration(Duration::new(60, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00m");
+    assert_eq!(format!("{d}"), "1.00m");
 }
 #[test]
 fn m_1() {
     let d = Folktime::duration(Duration::new(60, 599_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00m");
+    assert_eq!(format!("{d}"), "1.00m");
 }
 #[test]
 fn m_2() {
     let d = Folktime::duration(Duration::new(60, 600_000_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.01m");
+    assert_eq!(format!("{d}"), "1.01m");
 }
 #[test]
 fn m_3() {
     let d = Folktime::duration(Duration::new(61, 199_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.01m");
+    assert_eq!(format!("{d}"), "1.01m");
 }
 #[test]
 fn m_4() {
     let d = Folktime::duration(Duration::new(61, 200_000_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.02m");
+    assert_eq!(format!("{d}"), "1.02m");
 }
 #[test]
 fn m_5() {
     let d = Folktime::duration(Duration::new(90, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.50m");
+    assert_eq!(format!("{d}"), "1.50m");
 }
 #[test]
 fn m_6() {
     let d = Folktime::duration(Duration::new(120, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2.00m");
+    assert_eq!(format!("{d}"), "2.00m");
 }
 #[test]
 fn m_7() {
     let d = Folktime::duration(Duration::new(599, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "9.99m");
+    assert_eq!(format!("{d}"), "9.99m");
 }
 #[test]
 fn m_8() {
     let d = Folktime::duration(Duration::new(600, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0m");
+    assert_eq!(format!("{d}"), "10.0m");
 }
 #[test]
 fn m_9() {
     let d = Folktime::duration(Duration::new(605, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0m");
+    assert_eq!(format!("{d}"), "10.0m");
 }
 #[test]
 fn m_10() {
     let d = Folktime::duration(Duration::new(606, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.1m");
+    assert_eq!(format!("{d}"), "10.1m");
 }
 #[test]
 fn m_11() {
     let d = Folktime::duration(Duration::new(59 * MINUTE + 59, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "59.9m");
+    assert_eq!(format!("{d}"), "59.9m");
 }
 
 #[test]
 fn h_0() {
     let d = Folktime::duration(Duration::new(3600, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00h");
+    assert_eq!(format!("{d}"), "1.00h");
 }
 #[test]
 fn h_1() {
     let d = Folktime::duration(Duration::new(3635, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00h");
+    assert_eq!(format!("{d}"), "1.00h");
 }
 #[test]
 fn h_2() {
     let d = Folktime::duration(Duration::new(3636, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.01h");
+    assert_eq!(format!("{d}"), "1.01h");
 }
 #[test]
 fn h_3() {
     let d = Folktime::duration(Duration::new(3671, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.01h");
+    assert_eq!(format!("{d}"), "1.01h");
 }
 #[test]
 fn h_4() {
     let d = Folktime::duration(Duration::new(3672, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.02h");
+    assert_eq!(format!("{d}"), "1.02h");
 }
 #[test]
 fn h_5() {
     let d = Folktime::duration(Duration::new(5400, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.50h");
+    assert_eq!(format!("{d}"), "1.50h");
 }
 #[test]
 fn h_6() {
     let d = Folktime::duration(Duration::new(7199, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.99h");
+    assert_eq!(format!("{d}"), "1.99h");
 }
 #[test]
 fn h_7() {
     let d = Folktime::duration(Duration::new(7200, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2.00h");
+    assert_eq!(format!("{d}"), "2.00h");
 }
 #[test]
 fn h_8() {
     let d = Folktime::duration(Duration::new(9 * HOUR + 59 * MINUTE + 59, 999_999_999))
         .with_style(STYLE);
-    assert_eq!(format!("{}", d), "9.99h");
+    assert_eq!(format!("{d}"), "9.99h");
 }
 #[test]
 fn h_9() {
     let d = Folktime::duration(Duration::new(10 * HOUR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0h");
+    assert_eq!(format!("{d}"), "10.0h");
 }
 #[test]
 fn h_10() {
     let d = Folktime::duration(Duration::new(10 * HOUR + 5 * MINUTE + 59, 999_999_999))
         .with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0h");
+    assert_eq!(format!("{d}"), "10.0h");
 }
 #[test]
 fn h_11() {
     let d = Folktime::duration(Duration::new(10 * HOUR + 6 * MINUTE, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.1h");
+    assert_eq!(format!("{d}"), "10.1h");
 }
 #[test]
 fn h_12() {
     let d = Folktime::duration(Duration::new(23 * HOUR + 59 * MINUTE + 59, 999_999_999))
         .with_style(STYLE);
-    assert_eq!(format!("{}", d), "23.9h");
+    assert_eq!(format!("{d}"), "23.9h");
 }
 
 #[test]
 fn d_0() {
     let d = Folktime::duration(Duration::new(DAY, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00d");
+    assert_eq!(format!("{d}"), "1.00d");
 }
 #[test]
 fn d_1() {
     let d = Folktime::duration(Duration::new(DAY + 863, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00d");
+    assert_eq!(format!("{d}"), "1.00d");
 }
 #[test]
 fn d_2() {
     let d = Folktime::duration(Duration::new(DAY + 864, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.01d");
+    assert_eq!(format!("{d}"), "1.01d");
 }
 #[test]
 fn d_3() {
     let d = Folktime::duration(Duration::new(2 * DAY - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.99d");
+    assert_eq!(format!("{d}"), "1.99d");
 }
 #[test]
 fn d_4() {
     let d = Folktime::duration(Duration::new(2 * DAY, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2.00d");
+    assert_eq!(format!("{d}"), "2.00d");
 }
 #[test]
 fn d_5() {
     let d = Folktime::duration(Duration::new(2 * DAY + 12 * HOUR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2.50d");
+    assert_eq!(format!("{d}"), "2.50d");
 }
 #[test]
 fn d_6() {
     let d = Folktime::duration(Duration::new(WEEK - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "6.99d");
+    assert_eq!(format!("{d}"), "6.99d");
 }
 
 #[test]
 fn w_0() {
     let d = Folktime::duration(Duration::new(WEEK, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00w");
+    assert_eq!(format!("{d}"), "1.00w");
 }
 #[test]
 fn w_1() {
     let d = Folktime::duration(Duration::new(WEEK + 6047, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00w");
+    assert_eq!(format!("{d}"), "1.00w");
 }
 #[test]
 fn w_2() {
     let d = Folktime::duration(Duration::new(WEEK + 6048, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.01w");
+    assert_eq!(format!("{d}"), "1.01w");
 }
 #[test]
 fn w_3() {
     let d = Folktime::duration(Duration::new(2 * WEEK - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.99w");
+    assert_eq!(format!("{d}"), "1.99w");
 }
 #[test]
 fn w_4() {
     let d = Folktime::duration(Duration::new(2 * WEEK, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2.00w");
+    assert_eq!(format!("{d}"), "2.00w");
 }
 #[test]
 fn w_5() {
     let d = Folktime::duration(Duration::new(4 * WEEK, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "4.00w");
+    assert_eq!(format!("{d}"), "4.00w");
 }
 #[test]
 fn w_6() {
     let d = Folktime::duration(Duration::new(MONTH - 1, 999_999_999)).with_style(STYLE);
-    let s = format!("{}", d);
+    let s = format!("{d}");
 
     assert!(s.starts_with("4."));
     assert!(s.ends_with('w'));
@@ -427,199 +427,199 @@ fn w_6() {
 #[test]
 fn mo_0() {
     let d = Folktime::duration(Duration::new(MONTH, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00mo");
+    assert_eq!(format!("{d}"), "1.00mo");
 }
 #[test]
 fn mo_1() {
     let d = Folktime::duration(Duration::new(2 * MONTH - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.99mo");
+    assert_eq!(format!("{d}"), "1.99mo");
 }
 #[test]
 fn mo_2() {
     let d = Folktime::duration(Duration::new(2 * MONTH, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2.00mo");
+    assert_eq!(format!("{d}"), "2.00mo");
 }
 #[test]
 fn mo_3() {
     let d = Folktime::duration(Duration::new(6 * MONTH, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "6.00mo");
+    assert_eq!(format!("{d}"), "6.00mo");
 }
 #[test]
 fn mo_4() {
     let d = Folktime::duration(Duration::new(YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "11.9mo");
+    assert_eq!(format!("{d}"), "11.9mo");
 }
 
 #[test]
 fn y_0() {
     let d = Folktime::duration(Duration::new(YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00y");
+    assert_eq!(format!("{d}"), "1.00y");
 }
 #[test]
 fn y_1() {
     let d = Folktime::duration(Duration::new(2 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.99y");
+    assert_eq!(format!("{d}"), "1.99y");
 }
 #[test]
 fn y_2() {
     let d = Folktime::duration(Duration::new(2 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2.00y");
+    assert_eq!(format!("{d}"), "2.00y");
 }
 #[test]
 fn y_3() {
     let d = Folktime::duration(Duration::new(10 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0y");
+    assert_eq!(format!("{d}"), "10.0y");
 }
 #[test]
 fn y_4() {
     let d = Folktime::duration(Duration::new(100 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "100y");
+    assert_eq!(format!("{d}"), "100y");
 }
 #[test]
 fn y_5() {
     let d = Folktime::duration(Duration::new(999 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999y");
+    assert_eq!(format!("{d}"), "999y");
 }
 
 #[test]
 fn ky_0() {
     let d = Folktime::duration(Duration::new(1_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00ky");
+    assert_eq!(format!("{d}"), "1.00ky");
 }
 #[test]
 fn ky_1() {
     let d = Folktime::duration(Duration::new(1_010 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00ky");
+    assert_eq!(format!("{d}"), "1.00ky");
 }
 #[test]
 fn ky_2() {
     let d = Folktime::duration(Duration::new(1_010 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.01ky");
+    assert_eq!(format!("{d}"), "1.01ky");
 }
 #[test]
 fn ky_3() {
     let d = Folktime::duration(Duration::new(2_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2.00ky");
+    assert_eq!(format!("{d}"), "2.00ky");
 }
 #[test]
 fn ky_4() {
     let d = Folktime::duration(Duration::new(10_000 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "9.99ky");
+    assert_eq!(format!("{d}"), "9.99ky");
 }
 #[test]
 fn ky_5() {
     let d = Folktime::duration(Duration::new(10_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0ky");
+    assert_eq!(format!("{d}"), "10.0ky");
 }
 #[test]
 fn ky_6() {
     let d = Folktime::duration(Duration::new(100_000 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "99.9ky");
+    assert_eq!(format!("{d}"), "99.9ky");
 }
 #[test]
 fn ky_7() {
     let d = Folktime::duration(Duration::new(100_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "100ky");
+    assert_eq!(format!("{d}"), "100ky");
 }
 #[test]
 fn ky_8() {
     let d = Folktime::duration(Duration::new(1_000_000 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999ky");
+    assert_eq!(format!("{d}"), "999ky");
 }
 
 #[test]
 fn my_0() {
     let d = Folktime::duration(Duration::new(1_000_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00My");
+    assert_eq!(format!("{d}"), "1.00My");
 }
 #[test]
 fn my_1() {
     let d = Folktime::duration(Duration::new(1_010_000 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00My");
+    assert_eq!(format!("{d}"), "1.00My");
 }
 #[test]
 fn my_2() {
     let d = Folktime::duration(Duration::new(1_010_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.01My");
+    assert_eq!(format!("{d}"), "1.01My");
 }
 #[test]
 fn my_3() {
     let d = Folktime::duration(Duration::new(2_000_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2.00My");
+    assert_eq!(format!("{d}"), "2.00My");
 }
 #[test]
 fn my_4() {
     let d = Folktime::duration(Duration::new(10_000_000 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "9.99My");
+    assert_eq!(format!("{d}"), "9.99My");
 }
 #[test]
 fn my_5() {
     let d = Folktime::duration(Duration::new(10_000_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0My");
+    assert_eq!(format!("{d}"), "10.0My");
 }
 #[test]
 fn my_6() {
     let d =
         Folktime::duration(Duration::new(100_000_000 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "99.9My");
+    assert_eq!(format!("{d}"), "99.9My");
 }
 #[test]
 fn my_7() {
     let d = Folktime::duration(Duration::new(100_000_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "100My");
+    assert_eq!(format!("{d}"), "100My");
 }
 #[test]
 fn my_8() {
     let d =
         Folktime::duration(Duration::new(1_000_000_000 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999My");
+    assert_eq!(format!("{d}"), "999My");
 }
 
 #[test]
 fn gy_0() {
     let d = Folktime::duration(Duration::new(1_000_000_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00Gy");
+    assert_eq!(format!("{d}"), "1.00Gy");
 }
 #[test]
 fn gy_1() {
     let d =
         Folktime::duration(Duration::new(1_010_000_000 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.00Gy");
+    assert_eq!(format!("{d}"), "1.00Gy");
 }
 #[test]
 fn gy_2() {
     let d = Folktime::duration(Duration::new(1_010_000_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1.01Gy");
+    assert_eq!(format!("{d}"), "1.01Gy");
 }
 #[test]
 fn gy_3() {
     let d = Folktime::duration(Duration::new(2_000_000_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2.00Gy");
+    assert_eq!(format!("{d}"), "2.00Gy");
 }
 #[test]
 fn gy_4() {
     let d =
         Folktime::duration(Duration::new(10_000_000_000 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "9.99Gy");
+    assert_eq!(format!("{d}"), "9.99Gy");
 }
 #[test]
 fn gy_5() {
     let d = Folktime::duration(Duration::new(10_000_000_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "10.0Gy");
+    assert_eq!(format!("{d}"), "10.0Gy");
 }
 #[test]
 fn gy_6() {
     let d = Folktime::duration(Duration::new(100_000_000_000 * YEAR - 1, 999_999_999))
         .with_style(STYLE);
-    assert_eq!(format!("{}", d), "99.9Gy");
+    assert_eq!(format!("{d}"), "99.9Gy");
 }
 #[test]
 fn gy_7() {
     let d = Folktime::duration(Duration::new(100_000_000_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "100Gy");
+    assert_eq!(format!("{d}"), "100Gy");
 }
 #[test]
 fn gy_8() {
     let d = Folktime::duration(Duration::new(500_000_000_000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "500Gy");
+    assert_eq!(format!("{d}"), "500Gy");
 }

--- a/tests/one_unit_whole.rs
+++ b/tests/one_unit_whole.rs
@@ -1,315 +1,315 @@
 mod common;
 
 use common::*;
+use core::time::Duration;
 use folktime::Folktime;
 use folktime::duration::Style;
-use std::time::Duration;
 
 const STYLE: Style = Style::OneUnitWhole;
 
 #[test]
 fn zero() {
     let d = Folktime::duration(Duration::new(0, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "0s");
+    assert_eq!(format!("{d}"), "0s");
 }
 #[test]
 fn max() {
     let d = Folktime::duration(Duration::new(u64::MAX, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "584Gy");
+    assert_eq!(format!("{d}"), "584Gy");
 }
 #[test]
 fn test() {
     let d = Folktime::duration(Duration::from_secs(12345689)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "4mo");
+    assert_eq!(format!("{d}"), "4mo");
 }
 #[test]
 fn test2() {
     let d = Folktime::duration(Duration::from_secs(1234568)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2w");
+    assert_eq!(format!("{d}"), "2w");
 }
 
 #[test]
 fn ns_0() {
     let d = Folktime::duration(Duration::new(0, 1)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ns");
+    assert_eq!(format!("{d}"), "1ns");
 }
 #[test]
 fn ns_1() {
     let d = Folktime::duration(Duration::new(0, 999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999ns");
+    assert_eq!(format!("{d}"), "999ns");
 }
 
 #[test]
 fn us_0() {
     let d = Folktime::duration(Duration::new(0, 1_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1us");
+    assert_eq!(format!("{d}"), "1us");
 }
 #[test]
 fn us_1() {
     let d = Folktime::duration(Duration::new(0, 1_001)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1us");
+    assert_eq!(format!("{d}"), "1us");
 }
 #[test]
 fn us_2() {
     let d = Folktime::duration(Duration::new(0, 1_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1us");
+    assert_eq!(format!("{d}"), "1us");
 }
 #[test]
 fn us_3() {
     let d = Folktime::duration(Duration::new(0, 999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999us");
+    assert_eq!(format!("{d}"), "999us");
 }
 
 #[test]
 fn ms_0() {
     let d = Folktime::duration(Duration::new(0, 1_000_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ms");
+    assert_eq!(format!("{d}"), "1ms");
 }
 #[test]
 fn ms_1() {
     let d = Folktime::duration(Duration::new(0, 1_000_001)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ms");
+    assert_eq!(format!("{d}"), "1ms");
 }
 #[test]
 fn ms_2() {
     let d = Folktime::duration(Duration::new(0, 1_000_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ms");
+    assert_eq!(format!("{d}"), "1ms");
 }
 #[test]
 fn ms_3() {
     let d = Folktime::duration(Duration::new(0, 1_001_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ms");
+    assert_eq!(format!("{d}"), "1ms");
 }
 #[test]
 fn ms_4() {
     let d = Folktime::duration(Duration::new(0, 1_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ms");
+    assert_eq!(format!("{d}"), "1ms");
 }
 #[test]
 fn ms_5() {
     let d = Folktime::duration(Duration::new(0, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999ms");
+    assert_eq!(format!("{d}"), "999ms");
 }
 
 #[test]
 fn s_0() {
     let d = Folktime::duration(Duration::new(1, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1s");
+    assert_eq!(format!("{d}"), "1s");
 }
 #[test]
 fn s_1() {
     let d = Folktime::duration(Duration::new(1, 999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1s");
+    assert_eq!(format!("{d}"), "1s");
 }
 #[test]
 fn s_2() {
     let d = Folktime::duration(Duration::new(1, 1_000_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1s");
+    assert_eq!(format!("{d}"), "1s");
 }
 #[test]
 fn s_3() {
     let d = Folktime::duration(Duration::new(59, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "59s");
+    assert_eq!(format!("{d}"), "59s");
 }
 
 #[test]
 fn m_0() {
     let d = Folktime::duration(Duration::new(60, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1m");
+    assert_eq!(format!("{d}"), "1m");
 }
 #[test]
 fn m_1() {
     let d = Folktime::duration(Duration::new(60, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1m");
+    assert_eq!(format!("{d}"), "1m");
 }
 #[test]
 fn m_2() {
     let d = Folktime::duration(Duration::new(61, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1m");
+    assert_eq!(format!("{d}"), "1m");
 }
 #[test]
 fn m_3() {
     let d = Folktime::duration(Duration::new(HOUR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "59m");
+    assert_eq!(format!("{d}"), "59m");
 }
 
 #[test]
 fn h_0() {
     let d = Folktime::duration(Duration::new(HOUR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1h");
+    assert_eq!(format!("{d}"), "1h");
 }
 #[test]
 fn h_1() {
     let d = Folktime::duration(Duration::new(HOUR + MINUTE - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1h");
+    assert_eq!(format!("{d}"), "1h");
 }
 #[test]
 fn h_2() {
     let d = Folktime::duration(Duration::new(HOUR + MINUTE, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1h");
+    assert_eq!(format!("{d}"), "1h");
 }
 #[test]
 fn h_3() {
     let d = Folktime::duration(Duration::new(DAY - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "23h");
+    assert_eq!(format!("{d}"), "23h");
 }
 
 #[test]
 fn d_0() {
     let d = Folktime::duration(Duration::new(DAY, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1d");
+    assert_eq!(format!("{d}"), "1d");
 }
 #[test]
 fn d_1() {
     let d = Folktime::duration(Duration::new(DAY + HOUR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1d");
+    assert_eq!(format!("{d}"), "1d");
 }
 #[test]
 fn d_2() {
     let d = Folktime::duration(Duration::new(DAY + HOUR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1d");
+    assert_eq!(format!("{d}"), "1d");
 }
 #[test]
 fn d_3() {
     let d = Folktime::duration(Duration::new(WEEK - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "6d");
+    assert_eq!(format!("{d}"), "6d");
 }
 
 #[test]
 fn w_0() {
     let d = Folktime::duration(Duration::new(WEEK, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1w");
+    assert_eq!(format!("{d}"), "1w");
 }
 #[test]
 fn w_1() {
     let d = Folktime::duration(Duration::new(WEEK + DAY - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1w");
+    assert_eq!(format!("{d}"), "1w");
 }
 #[test]
 fn w_2() {
     let d = Folktime::duration(Duration::new(WEEK + DAY, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1w");
+    assert_eq!(format!("{d}"), "1w");
 }
 #[test]
 fn w_3() {
     let d = Folktime::duration(Duration::new(MONTH - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "4w");
+    assert_eq!(format!("{d}"), "4w");
 }
 
 #[test]
 fn mo_0() {
     let d = Folktime::duration(Duration::new(MONTH, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1mo");
+    assert_eq!(format!("{d}"), "1mo");
 }
 #[test]
 fn mo_1() {
     let d = Folktime::duration(Duration::new(MONTH + DAY - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1mo");
+    assert_eq!(format!("{d}"), "1mo");
 }
 #[test]
 fn mo_2() {
     let d = Folktime::duration(Duration::new(MONTH + DAY, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1mo");
+    assert_eq!(format!("{d}"), "1mo");
 }
 #[test]
 fn mo_3() {
     let d = Folktime::duration(Duration::new(YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "11mo");
+    assert_eq!(format!("{d}"), "11mo");
 }
 
 #[test]
 fn y_0() {
     let d = Folktime::duration(Duration::new(YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1y");
+    assert_eq!(format!("{d}"), "1y");
 }
 #[test]
 fn y_1() {
     let d = Folktime::duration(Duration::new(YEAR + MONTH - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1y");
+    assert_eq!(format!("{d}"), "1y");
 }
 #[test]
 fn y_2() {
     let d = Folktime::duration(Duration::new(YEAR + MONTH, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1y");
+    assert_eq!(format!("{d}"), "1y");
 }
 #[test]
 fn y_3() {
     let d = Folktime::duration(Duration::new(2 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1y");
+    assert_eq!(format!("{d}"), "1y");
 }
 #[test]
 fn y_4() {
     let d = Folktime::duration(Duration::new(2 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2y");
+    assert_eq!(format!("{d}"), "2y");
 }
 #[test]
 fn y_5() {
     let d = Folktime::duration(Duration::new(1000 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999y");
+    assert_eq!(format!("{d}"), "999y");
 }
 
 #[test]
 fn ky_0() {
     let d = Folktime::duration(Duration::new(1000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ky");
+    assert_eq!(format!("{d}"), "1ky");
 }
 #[test]
 fn ky_1() {
     let d =
         Folktime::duration(Duration::new(1000 * YEAR + YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ky");
+    assert_eq!(format!("{d}"), "1ky");
 }
 #[test]
 fn ky_2() {
     let d = Folktime::duration(Duration::new(1000 * YEAR + YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ky");
+    assert_eq!(format!("{d}"), "1ky");
 }
 #[test]
 fn ky_3() {
     let d = Folktime::duration(Duration::new(MEGA_YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999ky");
+    assert_eq!(format!("{d}"), "999ky");
 }
 
 #[test]
 fn my_0() {
     let d = Folktime::duration(Duration::new(MEGA_YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1My");
+    assert_eq!(format!("{d}"), "1My");
 }
 #[test]
 fn my_1() {
     let d = Folktime::duration(Duration::new(MEGA_YEAR + 1000 * YEAR - 1, 999_999_999))
         .with_style(STYLE);
-    assert_eq!(format!("{}", d), "1My");
+    assert_eq!(format!("{d}"), "1My");
 }
 #[test]
 fn my_2() {
     let d = Folktime::duration(Duration::new(MEGA_YEAR + 1000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1My");
+    assert_eq!(format!("{d}"), "1My");
 }
 #[test]
 fn my_3() {
     let d = Folktime::duration(Duration::new(GIGA_YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999My");
+    assert_eq!(format!("{d}"), "999My");
 }
 
 #[test]
 fn gy_0() {
     let d = Folktime::duration(Duration::new(GIGA_YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1Gy");
+    assert_eq!(format!("{d}"), "1Gy");
 }
 #[test]
 fn gy_1() {
     let d =
         Folktime::duration(Duration::new(GIGA_YEAR + MEGA_YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1Gy");
+    assert_eq!(format!("{d}"), "1Gy");
 }
 #[test]
 fn gy_2() {
     let d = Folktime::duration(Duration::new(GIGA_YEAR + MEGA_YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1Gy");
+    assert_eq!(format!("{d}"), "1Gy");
 }
 #[test]
 fn gy_3() {
     let d = Folktime::duration(Duration::new(500 * GIGA_YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "500Gy");
+    assert_eq!(format!("{d}"), "500Gy");
 }

--- a/tests/two_units_whole.rs
+++ b/tests/two_units_whole.rs
@@ -1,315 +1,315 @@
 mod common;
 
 use common::*;
+use core::time::Duration;
 use folktime::Folktime;
 use folktime::duration::Style;
-use std::time::Duration;
 
 const STYLE: Style = Style::TwoUnitsWhole;
 
 #[test]
 fn zero() {
     let d = Folktime::duration(Duration::new(0, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "0s 0ms");
+    assert_eq!(format!("{d}"), "0s 0ms");
 }
 #[test]
 fn max() {
     let d = Folktime::duration(Duration::new(u64::MAX, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "584Gy 531My");
+    assert_eq!(format!("{d}"), "584Gy 531My");
 }
 #[test]
 fn test() {
     let d = Folktime::duration(Duration::from_secs(12345689)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "4mo 21d");
+    assert_eq!(format!("{d}"), "4mo 21d");
 }
 #[test]
 fn test2() {
     let d = Folktime::duration(Duration::from_secs(1234568)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2w 0d");
+    assert_eq!(format!("{d}"), "2w 0d");
 }
 
 #[test]
 fn ns_0() {
     let d = Folktime::duration(Duration::new(0, 1)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ns");
+    assert_eq!(format!("{d}"), "1ns");
 }
 #[test]
 fn ns_1() {
     let d = Folktime::duration(Duration::new(0, 999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999ns");
+    assert_eq!(format!("{d}"), "999ns");
 }
 
 #[test]
 fn us_0() {
     let d = Folktime::duration(Duration::new(0, 1_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1us 0ns");
+    assert_eq!(format!("{d}"), "1us 0ns");
 }
 #[test]
 fn us_1() {
     let d = Folktime::duration(Duration::new(0, 1_001)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1us 1ns");
+    assert_eq!(format!("{d}"), "1us 1ns");
 }
 #[test]
 fn us_2() {
     let d = Folktime::duration(Duration::new(0, 1_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1us 999ns");
+    assert_eq!(format!("{d}"), "1us 999ns");
 }
 #[test]
 fn us_3() {
     let d = Folktime::duration(Duration::new(0, 999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999us 999ns");
+    assert_eq!(format!("{d}"), "999us 999ns");
 }
 
 #[test]
 fn ms_0() {
     let d = Folktime::duration(Duration::new(0, 1_000_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ms 0us");
+    assert_eq!(format!("{d}"), "1ms 0us");
 }
 #[test]
 fn ms_1() {
     let d = Folktime::duration(Duration::new(0, 1_000_001)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ms 0us");
+    assert_eq!(format!("{d}"), "1ms 0us");
 }
 #[test]
 fn ms_2() {
     let d = Folktime::duration(Duration::new(0, 1_000_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ms 0us");
+    assert_eq!(format!("{d}"), "1ms 0us");
 }
 #[test]
 fn ms_3() {
     let d = Folktime::duration(Duration::new(0, 1_001_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ms 1us");
+    assert_eq!(format!("{d}"), "1ms 1us");
 }
 #[test]
 fn ms_4() {
     let d = Folktime::duration(Duration::new(0, 1_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ms 999us");
+    assert_eq!(format!("{d}"), "1ms 999us");
 }
 #[test]
 fn ms_5() {
     let d = Folktime::duration(Duration::new(0, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999ms 999us");
+    assert_eq!(format!("{d}"), "999ms 999us");
 }
 
 #[test]
 fn s_0() {
     let d = Folktime::duration(Duration::new(1, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1s 0ms");
+    assert_eq!(format!("{d}"), "1s 0ms");
 }
 #[test]
 fn s_1() {
     let d = Folktime::duration(Duration::new(1, 999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1s 0ms");
+    assert_eq!(format!("{d}"), "1s 0ms");
 }
 #[test]
 fn s_2() {
     let d = Folktime::duration(Duration::new(1, 1_000_000)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1s 1ms");
+    assert_eq!(format!("{d}"), "1s 1ms");
 }
 #[test]
 fn s_3() {
     let d = Folktime::duration(Duration::new(59, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "59s 999ms");
+    assert_eq!(format!("{d}"), "59s 999ms");
 }
 
 #[test]
 fn m_0() {
     let d = Folktime::duration(Duration::new(60, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1m 0s");
+    assert_eq!(format!("{d}"), "1m 0s");
 }
 #[test]
 fn m_1() {
     let d = Folktime::duration(Duration::new(60, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1m 0s");
+    assert_eq!(format!("{d}"), "1m 0s");
 }
 #[test]
 fn m_2() {
     let d = Folktime::duration(Duration::new(61, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1m 1s");
+    assert_eq!(format!("{d}"), "1m 1s");
 }
 #[test]
 fn m_3() {
     let d = Folktime::duration(Duration::new(HOUR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "59m 59s");
+    assert_eq!(format!("{d}"), "59m 59s");
 }
 
 #[test]
 fn h_0() {
     let d = Folktime::duration(Duration::new(HOUR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1h 0m");
+    assert_eq!(format!("{d}"), "1h 0m");
 }
 #[test]
 fn h_1() {
     let d = Folktime::duration(Duration::new(HOUR + MINUTE - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1h 0m");
+    assert_eq!(format!("{d}"), "1h 0m");
 }
 #[test]
 fn h_2() {
     let d = Folktime::duration(Duration::new(HOUR + MINUTE, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1h 1m");
+    assert_eq!(format!("{d}"), "1h 1m");
 }
 #[test]
 fn h_3() {
     let d = Folktime::duration(Duration::new(DAY - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "23h 59m");
+    assert_eq!(format!("{d}"), "23h 59m");
 }
 
 #[test]
 fn d_0() {
     let d = Folktime::duration(Duration::new(DAY, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1d 0h");
+    assert_eq!(format!("{d}"), "1d 0h");
 }
 #[test]
 fn d_1() {
     let d = Folktime::duration(Duration::new(DAY + HOUR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1d 0h");
+    assert_eq!(format!("{d}"), "1d 0h");
 }
 #[test]
 fn d_2() {
     let d = Folktime::duration(Duration::new(DAY + HOUR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1d 1h");
+    assert_eq!(format!("{d}"), "1d 1h");
 }
 #[test]
 fn d_3() {
     let d = Folktime::duration(Duration::new(WEEK - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "6d 23h");
+    assert_eq!(format!("{d}"), "6d 23h");
 }
 
 #[test]
 fn w_0() {
     let d = Folktime::duration(Duration::new(WEEK, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1w 0d");
+    assert_eq!(format!("{d}"), "1w 0d");
 }
 #[test]
 fn w_1() {
     let d = Folktime::duration(Duration::new(WEEK + DAY - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1w 0d");
+    assert_eq!(format!("{d}"), "1w 0d");
 }
 #[test]
 fn w_2() {
     let d = Folktime::duration(Duration::new(WEEK + DAY, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1w 1d");
+    assert_eq!(format!("{d}"), "1w 1d");
 }
 #[test]
 fn w_3() {
     let d = Folktime::duration(Duration::new(MONTH - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "4w 2d");
+    assert_eq!(format!("{d}"), "4w 2d");
 }
 
 #[test]
 fn mo_0() {
     let d = Folktime::duration(Duration::new(MONTH, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1mo 0d");
+    assert_eq!(format!("{d}"), "1mo 0d");
 }
 #[test]
 fn mo_1() {
     let d = Folktime::duration(Duration::new(MONTH + DAY - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1mo 0d");
+    assert_eq!(format!("{d}"), "1mo 0d");
 }
 #[test]
 fn mo_2() {
     let d = Folktime::duration(Duration::new(MONTH + DAY, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1mo 1d");
+    assert_eq!(format!("{d}"), "1mo 1d");
 }
 #[test]
 fn mo_3() {
     let d = Folktime::duration(Duration::new(YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "11mo 30d");
+    assert_eq!(format!("{d}"), "11mo 30d");
 }
 
 #[test]
 fn y_0() {
     let d = Folktime::duration(Duration::new(YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1y 0mo");
+    assert_eq!(format!("{d}"), "1y 0mo");
 }
 #[test]
 fn y_1() {
     let d = Folktime::duration(Duration::new(YEAR + MONTH - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1y 0mo");
+    assert_eq!(format!("{d}"), "1y 0mo");
 }
 #[test]
 fn y_2() {
     let d = Folktime::duration(Duration::new(YEAR + MONTH, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1y 1mo");
+    assert_eq!(format!("{d}"), "1y 1mo");
 }
 #[test]
 fn y_3() {
     let d = Folktime::duration(Duration::new(2 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1y 11mo");
+    assert_eq!(format!("{d}"), "1y 11mo");
 }
 #[test]
 fn y_4() {
     let d = Folktime::duration(Duration::new(2 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "2y 0mo");
+    assert_eq!(format!("{d}"), "2y 0mo");
 }
 #[test]
 fn y_5() {
     let d = Folktime::duration(Duration::new(1000 * YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999y 11mo");
+    assert_eq!(format!("{d}"), "999y 11mo");
 }
 
 #[test]
 fn ky_0() {
     let d = Folktime::duration(Duration::new(1000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ky 0y");
+    assert_eq!(format!("{d}"), "1ky 0y");
 }
 #[test]
 fn ky_1() {
     let d =
         Folktime::duration(Duration::new(1000 * YEAR + YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ky 0y");
+    assert_eq!(format!("{d}"), "1ky 0y");
 }
 #[test]
 fn ky_2() {
     let d = Folktime::duration(Duration::new(1000 * YEAR + YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1ky 1y");
+    assert_eq!(format!("{d}"), "1ky 1y");
 }
 #[test]
 fn ky_3() {
     let d = Folktime::duration(Duration::new(MEGA_YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999ky 999y");
+    assert_eq!(format!("{d}"), "999ky 999y");
 }
 
 #[test]
 fn my_0() {
     let d = Folktime::duration(Duration::new(MEGA_YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1My 0ky");
+    assert_eq!(format!("{d}"), "1My 0ky");
 }
 #[test]
 fn my_1() {
     let d = Folktime::duration(Duration::new(MEGA_YEAR + 1000 * YEAR - 1, 999_999_999))
         .with_style(STYLE);
-    assert_eq!(format!("{}", d), "1My 0ky");
+    assert_eq!(format!("{d}"), "1My 0ky");
 }
 #[test]
 fn my_2() {
     let d = Folktime::duration(Duration::new(MEGA_YEAR + 1000 * YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1My 1ky");
+    assert_eq!(format!("{d}"), "1My 1ky");
 }
 #[test]
 fn my_3() {
     let d = Folktime::duration(Duration::new(GIGA_YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "999My 999ky");
+    assert_eq!(format!("{d}"), "999My 999ky");
 }
 
 #[test]
 fn gy_0() {
     let d = Folktime::duration(Duration::new(GIGA_YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1Gy 0My");
+    assert_eq!(format!("{d}"), "1Gy 0My");
 }
 #[test]
 fn gy_1() {
     let d =
         Folktime::duration(Duration::new(GIGA_YEAR + MEGA_YEAR - 1, 999_999_999)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1Gy 0My");
+    assert_eq!(format!("{d}"), "1Gy 0My");
 }
 #[test]
 fn gy_2() {
     let d = Folktime::duration(Duration::new(GIGA_YEAR + MEGA_YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "1Gy 1My");
+    assert_eq!(format!("{d}"), "1Gy 1My");
 }
 #[test]
 fn gy_3() {
     let d = Folktime::duration(Duration::new(500 * GIGA_YEAR, 0)).with_style(STYLE);
-    assert_eq!(format!("{}", d), "500Gy 0My");
+    assert_eq!(format!("{d}"), "500Gy 0My");
 }


### PR DESCRIPTION
Updates README and API examples to use `core::time::Duration` and inline format args, adds README doctests, and refreshes test/code metadata cleanup.