### PR TITLE
Add opt-in micro sign for microseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ assert_eq!(format!("{b}"), "0.50s");
 assert_eq!(format!("{c}"), "0s 500ms");
 ```
 
+## Unicode Microseconds
+
+Use [`Duration::with_micro_sign`](https://docs.rs/folktime/latest/folktime/duration/struct.Duration.html#method.with_micro_sign)
+to render microseconds with the micro sign:
+
+```rust
+use core::time::Duration;
+use folktime::Folktime;
+use folktime::duration::Style;
+
+let d = Folktime::duration(Duration::from_micros(12))
+    .with_style(Style::OneUnitWhole)
+    .with_micro_sign();
+
+assert_eq!(format!("{d}"), "12μs");
+```
+
 ## Notes
 
 - All styles support the full range of `core::time::Duration`.

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -37,7 +37,7 @@ const MS: u32 = 1_000 * US;
 pub enum Unit {
     /// Nanoseconds (`ns`).
     Nanosecond,
-    /// Microseconds (`us`).
+    /// Microseconds (`us` by default, or `μs` with [`Duration::with_micro_sign`]).
     Microsecond,
     /// Milliseconds (`ms`).
     Millisecond,
@@ -115,6 +115,7 @@ pub struct Duration {
     pub(crate) duration: core::time::Duration,
     pub(crate) style: Style,
     pub(crate) min_unit: Unit,
+    pub(crate) micro_sign: bool,
 }
 
 impl Duration {
@@ -124,6 +125,7 @@ impl Duration {
             duration: d,
             style: Style::OneUnitFrac,
             min_unit: Unit::Nanosecond,
+            micro_sign: false,
         }
     }
 
@@ -143,6 +145,29 @@ impl Duration {
     #[must_use]
     pub const fn with_style(self, style: Style) -> Self {
         Self { style, ..self }
+    }
+
+    /// Render microseconds with the micro sign (`μs`) instead of ASCII (`us`).
+    ///
+    /// This only affects outputs that include microseconds.
+    ///
+    /// # Example
+    /// ```
+    /// use core::time::Duration;
+    /// use folktime::Folktime;
+    /// use folktime::duration::Style;
+    ///
+    /// let d = Folktime::duration(Duration::from_micros(12))
+    ///     .with_style(Style::OneUnitWhole)
+    ///     .with_micro_sign();
+    /// assert_eq!(format!("{d}"), "12μs");
+    /// ```
+    #[must_use]
+    pub const fn with_micro_sign(self) -> Self {
+        Self {
+            micro_sign: true,
+            ..self
+        }
     }
 
     /// Set the smallest unit the formatter may choose.
@@ -176,6 +201,10 @@ impl Duration {
             min_unit: unit,
             ..self
         }
+    }
+
+    pub(crate) const fn microsecond_label(&self) -> &'static str {
+        if self.micro_sign { "μs" } else { "us" }
     }
 }
 

--- a/src/duration/one_unit_frac.rs
+++ b/src/duration/one_unit_frac.rs
@@ -42,6 +42,7 @@ impl Duration {
         let secs = self.duration.as_secs();
         let ns = self.duration.subsec_nanos();
         let min = self.min_unit;
+        let us_label = self.microsecond_label();
 
         if secs < 1 && min <= Unit::Millisecond {
             if ns < US && min <= Unit::Nanosecond {
@@ -53,7 +54,7 @@ impl Duration {
             } else if ns < MS && min <= Unit::Microsecond {
                 let us = ns / US;
                 let ns = ns % US;
-                fmt_three_u32(us, ns, "us", f)
+                fmt_three_u32(us, ns, us_label, f)
             } else {
                 let ms = ns / MS;
                 let us = (ns % MS) / US;

--- a/src/duration/one_unit_whole.rs
+++ b/src/duration/one_unit_whole.rs
@@ -7,6 +7,7 @@ impl Duration {
         let secs = self.duration.as_secs();
         let ns = self.duration.subsec_nanos();
         let min = self.min_unit;
+        let us_label = self.microsecond_label();
 
         if secs < 1 && min <= Unit::Millisecond {
             if ns < US && min <= Unit::Nanosecond {
@@ -17,7 +18,7 @@ impl Duration {
                 }
             } else if ns < MS && min <= Unit::Microsecond {
                 let us = ns / US;
-                write!(f, "{us}us")
+                write!(f, "{us}{us_label}")
             } else {
                 let ms = ns / MS;
                 write!(f, "{ms}ms")

--- a/src/duration/two_units_whole.rs
+++ b/src/duration/two_units_whole.rs
@@ -7,6 +7,7 @@ impl Duration {
         let secs = self.duration.as_secs();
         let ns = self.duration.subsec_nanos();
         let min = self.min_unit;
+        let us_label = self.microsecond_label();
 
         if secs < 1 && min <= Unit::Millisecond {
             if ns < US && min <= Unit::Nanosecond {
@@ -18,11 +19,11 @@ impl Duration {
             } else if ns < MS && min <= Unit::Microsecond {
                 let us = ns / US;
                 let ns = ns % US;
-                write!(f, "{us}us {ns}ns")
+                write!(f, "{us}{us_label} {ns}ns")
             } else {
                 let ms = ns / MS;
                 let us = (ns % MS) / US;
-                write!(f, "{ms}ms {us}us")
+                write!(f, "{ms}ms {us}{us_label}")
             }
         } else if secs < MINUTE && min <= Unit::Second {
             let ms = ns / 1_000_000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,21 @@ impl Folktime {
     /// assert_eq!(format!("{a}"), "500ms");
     /// assert_eq!(format!("{b}"), "0.50s");
     /// ```
+    ///
+    /// # Microsecond Label
+    /// Use [`Duration::with_micro_sign`] to render microseconds with the micro
+    /// sign:
+    /// ```
+    /// # use core::time::Duration;
+    /// # use folktime::Folktime;
+    /// use folktime::duration::Style;
+    ///
+    /// let d = Folktime::duration(Duration::from_micros(12))
+    ///     .with_style(Style::OneUnitWhole)
+    ///     .with_micro_sign();
+    ///
+    /// assert_eq!(format!("{d}"), "12μs");
+    /// ```
     #[must_use]
     pub const fn duration(d: core::time::Duration) -> Duration {
         Duration::new(d)

--- a/tests/no_alloc.rs
+++ b/tests/no_alloc.rs
@@ -80,6 +80,14 @@ fn one_unit_frac_does_not_allocate() {
         write!(buf, "{}", Folktime::duration(Duration::from_micros(500))).unwrap()
     });
     assert_no_alloc(|buf| {
+        write!(
+            buf,
+            "{}",
+            Folktime::duration(Duration::from_micros(500)).with_micro_sign()
+        )
+        .unwrap()
+    });
+    assert_no_alloc(|buf| {
         write!(buf, "{}", Folktime::duration(Duration::from_millis(123))).unwrap()
     });
     assert_no_alloc(|buf| write!(buf, "{}", Folktime::duration(Duration::from_secs(5))).unwrap());

--- a/tests/one_unit_frac.rs
+++ b/tests/one_unit_frac.rs
@@ -111,6 +111,14 @@ fn us_13() {
 }
 
 #[test]
+fn us_unicode() {
+    let d = Folktime::duration(Duration::new(0, 12_000))
+        .with_style(STYLE)
+        .with_micro_sign();
+    assert_eq!(format!("{d}"), "12.0μs");
+}
+
+#[test]
 fn ms_0() {
     let d = Folktime::duration(Duration::new(0, 1_000_000)).with_style(STYLE);
     assert_eq!(format!("{d}"), "1.00ms");

--- a/tests/one_unit_whole.rs
+++ b/tests/one_unit_whole.rs
@@ -61,6 +61,14 @@ fn us_3() {
 }
 
 #[test]
+fn us_unicode() {
+    let d = Folktime::duration(Duration::new(0, 12_000))
+        .with_style(STYLE)
+        .with_micro_sign();
+    assert_eq!(format!("{d}"), "12μs");
+}
+
+#[test]
 fn ms_0() {
     let d = Folktime::duration(Duration::new(0, 1_000_000)).with_style(STYLE);
     assert_eq!(format!("{d}"), "1ms");

--- a/tests/two_units_whole.rs
+++ b/tests/two_units_whole.rs
@@ -61,6 +61,14 @@ fn us_3() {
 }
 
 #[test]
+fn us_unicode() {
+    let d = Folktime::duration(Duration::new(0, 12_034))
+        .with_style(STYLE)
+        .with_micro_sign();
+    assert_eq!(format!("{d}"), "12μs 34ns");
+}
+
+#[test]
 fn ms_0() {
     let d = Folktime::duration(Duration::new(0, 1_000_000)).with_style(STYLE);
     assert_eq!(format!("{d}"), "1ms 0us");
@@ -89,6 +97,14 @@ fn ms_4() {
 fn ms_5() {
     let d = Folktime::duration(Duration::new(0, 999_999_999)).with_style(STYLE);
     assert_eq!(format!("{d}"), "999ms 999us");
+}
+
+#[test]
+fn ms_unicode_remainder() {
+    let d = Folktime::duration(Duration::new(0, 1_012_000))
+        .with_style(STYLE)
+        .with_micro_sign();
+    assert_eq!(format!("{d}"), "1ms 12μs");
 }
 
 #[test]


### PR DESCRIPTION
Allow callers to render microseconds as μs while preserving the existing ASCII us output by default.

Closes #6 